### PR TITLE
 feat(core): add feature-flagged Upstash Redis cache with memory fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,14 @@
         "typescript": "catalog:",
       },
     },
+    "packages/core": {
+      "name": "@otm/core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@otm/env": "workspace:*",
+        "@upstash/redis": "^1.35.4",
+      },
+    },
     "packages/db": {
       "name": "@otm/db",
       "version": "0.1.0",
@@ -416,6 +424,8 @@
 
     "@otm/auth": ["@otm/auth@workspace:packages/auth"],
 
+    "@otm/core": ["@otm/core@workspace:packages/core"],
+
     "@otm/db": ["@otm/db@workspace:packages/db"],
 
     "@otm/env": ["@otm/env@workspace:packages/env"],
@@ -583,6 +593,8 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@upstash/redis": ["@upstash/redis@1.35.4", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-WE1ZnhFyBiIjTDW13GbO6JjkiMVVjw5VsvS8ENmvvJsze/caMQ5paxVD44+U68IUVmkXcbsLSoE+VIYsHtbQEw=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,9 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "dev": "bun --watch src/index.ts"
+    "dev": "bun --watch src/index.ts",
+    "smoke": "tsx scripts/smoke.ts",
+    "flags:smoke": "tsx scripts/flags-smoke.ts"
   },
   "dependencies": {
     "@otm/env": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "dev": "bun --watch src/index.ts"
   },
   "dependencies": {
-    "@otm/env": "workspace:*"
+    "@otm/env": "workspace:*",
+    "@upstash/redis": "^1.35.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@otm/core",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "dev": "bun --watch src/index.ts"
+  },
+  "dependencies": {
+    "@otm/env": "workspace:*"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,8 +9,8 @@
   "types": "./src/index.ts",
   "scripts": {
     "dev": "bun --watch src/index.ts",
-    "smoke": "tsx scripts/smoke.ts",
-    "flags:smoke": "tsx scripts/flags-smoke.ts"
+    "smoke": "bun x tsx scripts/smoke.ts",
+    "flags:smoke": "bun x tsx scripts/flags-smoke.ts"
   },
   "dependencies": {
     "@otm/env": "workspace:*",

--- a/packages/core/scripts/flags-smoke.ts
+++ b/packages/core/scripts/flags-smoke.ts
@@ -1,0 +1,15 @@
+import { isFeatureEnabled } from "../src/utils/feature-flags";
+import { setFeatureFlag, clearFeatureFlag } from "../src/utils/feature-flags";
+
+async function main() {
+  await setFeatureFlag("beta_ui", true, 2);
+  console.log("beta_ui (immediate):", await isFeatureEnabled("beta_ui"));
+  await new Promise((r) => setTimeout(r, 2500));
+  console.log("beta_ui (after 2.5s):", await isFeatureEnabled("beta_ui"));
+  await clearFeatureFlag("beta_ui");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/core/scripts/smoke.ts
+++ b/packages/core/scripts/smoke.ts
@@ -1,0 +1,6 @@
+import { cache } from "../src/index";
+
+(async () => {
+  await cache.set("k", "v", 1);
+  console.log("GET:", await cache.get("k"));
+})();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./lib/cache";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./lib/cache";
+export * from "./utils/feature-flags";

--- a/packages/core/src/lib/cache.ts
+++ b/packages/core/src/lib/cache.ts
@@ -1,4 +1,5 @@
 import { env } from "@otm/env";
+import { createUpstashCache } from "./providers/upstash";
 
 export type Cache = {
   get<T = unknown>(key: string): Promise<T | null>;
@@ -37,9 +38,6 @@ function makeCache(): Cache {
     Boolean(env.OTM_UPSTASH_REDIS_REST_TOKEN);
 
   if (enabled && hasUpstash) {
-    const { createUpstashCache } = require("./providers/upstash") as {
-      createUpstashCache: () => Cache;
-    };
     console.info("✅ OTM cache: Upstash (REST)");
     return createUpstashCache();
   }

--- a/packages/core/src/lib/cache.ts
+++ b/packages/core/src/lib/cache.ts
@@ -1,118 +1,31 @@
-import { env } from "../../../env/src";
+const store = new Map<string, { value: unknown; exp?: number }>();
+const now = () => Date.now();
 
-export interface Cache {
-  get: <T = unknown>(key: string) => Promise<T | null>;
-  set: (key: string, value: unknown, ttlSeconds?: number) => Promise<void>;
-  del: (key: string) => Promise<void>;
-}
+export type Cache = {
+  get<T = unknown>(key: string): Promise<T | null>;
+  set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+  del(key: string): Promise<void>;
+};
 
-/** In-memory fallback with TTL */
-function createMemoryCache(): Cache {
-  const store = new Map<string, { value: unknown; exp?: number }>();
-  const now = () => Date.now();
-
-  return {
-    async get<T>(key) {
-      const hit = store.get(key);
-      if (!hit) return null;
-      if (hit.exp && hit.exp < now()) {
-        store.delete(key);
-        return null;
-      }
-      return hit.value as T;
-    },
-    async set(key, value, ttl) {
-      const exp = ttl ? now() + ttl * 1000 : undefined;
-      store.set(key, { value, exp });
-    },
-    async del(key) {
+const memoryCache: Cache = {
+  async get<T>(key) {
+    const item = store.get(key);
+    if (!item) return null;
+    if (item.exp && item.exp < now()) {
       store.delete(key);
-    },
-  };
-}
+      return null;
+    }
+    return item.value as T;
+  },
 
-/** Upstash (HTTP/REST) provider */
-function createUpstashCache(): Cache {
-  // Lazy import so the package isn’t required if unused
-  // @ts-ignore
-  const { Redis } = require("@upstash/redis");
-  const client = new Redis({
-    url: env.server.OTM_UPSTASH_REDIS_REST_URL!,
-    token: env.server.OTM_UPSTASH_REDIS_REST_TOKEN!,
-  });
+  async set(key, value, ttlSeconds) {
+    const exp = ttlSeconds ? now() + ttlSeconds * 1000 : undefined;
+    store.set(key, { value, exp });
+  },
 
-  return {
-    async get<T>(key) {
-      const val = await client.get(key);
-      return (val ?? null) as T | null;
-    },
-    async set(key, value, ttlSeconds) {
-      const opts = ttlSeconds ? { ex: ttlSeconds } : undefined;
-      await client.set(key, value, opts);
-    },
-    async del(key) {
-      await client.del(key);
-    },
-  };
-}
+  async del(key) {
+    store.delete(key);
+  },
+};
 
-/** Local Docker Redis (RESP) provider */
-function createLocalRedisCache(): Cache {
-  // Lazy import; only needed if you use Docker Redis
-  // @ts-ignore
-  const { createClient } = require("redis");
-  const client = createClient({ url: env.server.OTM_LOCAL_REDIS_URL! });
-  client.connect();
-
-  return {
-    async get<T>(key) {
-      const raw = await client.get(key);
-      if (raw == null) return null;
-      try {
-        return JSON.parse(raw) as T;
-      } catch {
-        // If something else stored plain strings
-        return raw as unknown as T;
-      }
-    },
-    async set(key, value, ttlSeconds) {
-      const data = typeof value === "string" ? value : JSON.stringify(value);
-      if (ttlSeconds) {
-        await client.set(key, data, { EX: ttlSeconds });
-      } else {
-        await client.set(key, data);
-      }
-    },
-    async del(key) {
-      await client.del(key);
-    },
-  };
-}
-
-/** Factory: choose provider by env */
-function selectCache(): Cache {
-  if (env.server.OTM_REDIS_ENABLED !== "true") {
-    console.info("⚙️ OTM cache disabled — using in-memory fallback");
-    return createMemoryCache();
-  }
-
-  if (
-    env.server.OTM_UPSTASH_REDIS_REST_URL &&
-    env.server.OTM_UPSTASH_REDIS_REST_TOKEN
-  ) {
-    console.info("✅ Using Upstash Redis (REST)");
-    return createUpstashCache();
-  }
-
-  if (env.server.OTM_LOCAL_REDIS_URL) {
-    console.info("✅ Using local Redis (RESP)");
-    return createLocalRedisCache();
-  }
-
-  console.warn(
-    "⚠️ OTM_REDIS_ENABLED=true but no provider configured — falling back to memory"
-  );
-  return createMemoryCache();
-}
-
-export const cache: Cache = selectCache();
+export const cache: Cache = memoryCache;

--- a/packages/core/src/lib/cache.ts
+++ b/packages/core/src/lib/cache.ts
@@ -1,5 +1,4 @@
-const store = new Map<string, { value: unknown; exp?: number }>();
-const now = () => Date.now();
+import { env } from "@otm/env";
 
 export type Cache = {
   get<T = unknown>(key: string): Promise<T | null>;
@@ -7,25 +6,46 @@ export type Cache = {
   del(key: string): Promise<void>;
 };
 
-const memoryCache: Cache = {
-  async get<T>(key) {
-    const item = store.get(key);
-    if (!item) return null;
-    if (item.exp && item.exp < now()) {
+const store = new Map<string, { value: unknown; exp?: number }>();
+const now = (): number => Date.now();
+
+function createMemoryCache(): Cache {
+  return {
+    async get<T = unknown>(key: string): Promise<T | null> {
+      const item = store.get(key);
+      if (!item) return null;
+      if (item.exp && item.exp < now()) {
+        store.delete(key);
+        return null;
+      }
+      return item.value as T;
+    },
+    async set(key: string, value: unknown, ttlSeconds?: number): Promise<void> {
+      const exp = ttlSeconds ? now() + ttlSeconds * 1000 : undefined;
+      store.set(key, { value, exp });
+    },
+    async del(key: string): Promise<void> {
       store.delete(key);
-      return null;
-    }
-    return item.value as T;
-  },
+    },
+  };
+}
 
-  async set(key, value, ttlSeconds) {
-    const exp = ttlSeconds ? now() + ttlSeconds * 1000 : undefined;
-    store.set(key, { value, exp });
-  },
+function makeCache(): Cache {
+  const enabled: boolean = env.OTM_REDIS_ENABLED === "true";
+  const hasUpstash: boolean =
+    Boolean(env.OTM_UPSTASH_REDIS_REST_URL) &&
+    Boolean(env.OTM_UPSTASH_REDIS_REST_TOKEN);
 
-  async del(key) {
-    store.delete(key);
-  },
-};
+  if (enabled && hasUpstash) {
+    const { createUpstashCache } = require("./providers/upstash") as {
+      createUpstashCache: () => Cache;
+    };
+    console.info("✅ OTM cache: Upstash (REST)");
+    return createUpstashCache();
+  }
 
-export const cache: Cache = memoryCache;
+  console.info("⚙️ OTM cache: in-memory");
+  return createMemoryCache();
+}
+
+export const cache: Cache = makeCache();

--- a/packages/core/src/lib/cache.ts
+++ b/packages/core/src/lib/cache.ts
@@ -1,0 +1,118 @@
+import { env } from "../../../env/src";
+
+export interface Cache {
+  get: <T = unknown>(key: string) => Promise<T | null>;
+  set: (key: string, value: unknown, ttlSeconds?: number) => Promise<void>;
+  del: (key: string) => Promise<void>;
+}
+
+/** In-memory fallback with TTL */
+function createMemoryCache(): Cache {
+  const store = new Map<string, { value: unknown; exp?: number }>();
+  const now = () => Date.now();
+
+  return {
+    async get<T>(key) {
+      const hit = store.get(key);
+      if (!hit) return null;
+      if (hit.exp && hit.exp < now()) {
+        store.delete(key);
+        return null;
+      }
+      return hit.value as T;
+    },
+    async set(key, value, ttl) {
+      const exp = ttl ? now() + ttl * 1000 : undefined;
+      store.set(key, { value, exp });
+    },
+    async del(key) {
+      store.delete(key);
+    },
+  };
+}
+
+/** Upstash (HTTP/REST) provider */
+function createUpstashCache(): Cache {
+  // Lazy import so the package isn’t required if unused
+  // @ts-ignore
+  const { Redis } = require("@upstash/redis");
+  const client = new Redis({
+    url: env.server.OTM_UPSTASH_REDIS_REST_URL!,
+    token: env.server.OTM_UPSTASH_REDIS_REST_TOKEN!,
+  });
+
+  return {
+    async get<T>(key) {
+      const val = await client.get(key);
+      return (val ?? null) as T | null;
+    },
+    async set(key, value, ttlSeconds) {
+      const opts = ttlSeconds ? { ex: ttlSeconds } : undefined;
+      await client.set(key, value, opts);
+    },
+    async del(key) {
+      await client.del(key);
+    },
+  };
+}
+
+/** Local Docker Redis (RESP) provider */
+function createLocalRedisCache(): Cache {
+  // Lazy import; only needed if you use Docker Redis
+  // @ts-ignore
+  const { createClient } = require("redis");
+  const client = createClient({ url: env.server.OTM_LOCAL_REDIS_URL! });
+  client.connect();
+
+  return {
+    async get<T>(key) {
+      const raw = await client.get(key);
+      if (raw == null) return null;
+      try {
+        return JSON.parse(raw) as T;
+      } catch {
+        // If something else stored plain strings
+        return raw as unknown as T;
+      }
+    },
+    async set(key, value, ttlSeconds) {
+      const data = typeof value === "string" ? value : JSON.stringify(value);
+      if (ttlSeconds) {
+        await client.set(key, data, { EX: ttlSeconds });
+      } else {
+        await client.set(key, data);
+      }
+    },
+    async del(key) {
+      await client.del(key);
+    },
+  };
+}
+
+/** Factory: choose provider by env */
+function selectCache(): Cache {
+  if (env.server.OTM_REDIS_ENABLED !== "true") {
+    console.info("⚙️ OTM cache disabled — using in-memory fallback");
+    return createMemoryCache();
+  }
+
+  if (
+    env.server.OTM_UPSTASH_REDIS_REST_URL &&
+    env.server.OTM_UPSTASH_REDIS_REST_TOKEN
+  ) {
+    console.info("✅ Using Upstash Redis (REST)");
+    return createUpstashCache();
+  }
+
+  if (env.server.OTM_LOCAL_REDIS_URL) {
+    console.info("✅ Using local Redis (RESP)");
+    return createLocalRedisCache();
+  }
+
+  console.warn(
+    "⚠️ OTM_REDIS_ENABLED=true but no provider configured — falling back to memory"
+  );
+  return createMemoryCache();
+}
+
+export const cache: Cache = selectCache();

--- a/packages/core/src/lib/providers/upstash.ts
+++ b/packages/core/src/lib/providers/upstash.ts
@@ -1,0 +1,25 @@
+import { env } from "@otm/env";
+import type { Cache } from "../cache";
+
+const { Redis } = require("@upstash/redis") as typeof import("@upstash/redis");
+
+export function createUpstashCache(): Cache {
+  const client = new Redis({
+    url: env.OTM_UPSTASH_REDIS_REST_URL!,
+    token: env.OTM_UPSTASH_REDIS_REST_TOKEN!,
+  });
+
+  return {
+    async get<T = unknown>(key: string): Promise<T | null> {
+      const v = await client.get<T>(key);
+      return (v ?? null) as T | null;
+    },
+    async set(key: string, value: unknown, ttlSeconds?: number): Promise<void> {
+      const opts = ttlSeconds ? { ex: ttlSeconds } : undefined;
+      await client.set(key, value, opts);
+    },
+    async del(key: string): Promise<void> {
+      await client.del(key);
+    },
+  };
+}

--- a/packages/core/src/lib/providers/upstash.ts
+++ b/packages/core/src/lib/providers/upstash.ts
@@ -1,7 +1,7 @@
+import { Redis } from "@upstash/redis";
+
 import { env } from "@otm/env";
 import type { Cache } from "../cache";
-
-const { Redis } = require("@upstash/redis") as typeof import("@upstash/redis");
 
 export function createUpstashCache(): Cache {
   const client = new Redis({

--- a/packages/core/src/utils/feature-flags.ts
+++ b/packages/core/src/utils/feature-flags.ts
@@ -1,0 +1,20 @@
+import { cache } from "../lib/cache";
+
+const k = (name: string) => `flag:${name}`;
+
+export async function setFeatureFlag(
+  name: string,
+  enabled: boolean,
+  ttlSeconds?: number
+) {
+  await cache.set(k(name), enabled ? "true" : "false", ttlSeconds);
+}
+
+export async function isFeatureEnabled(name: string): Promise<boolean> {
+  const v = await cache.get<string>(k(name));
+  return v === "true";
+}
+
+export async function clearFeatureFlag(name: string) {
+  await cache.del(k(name));
+}

--- a/packages/core/src/utils/feature-flags.ts
+++ b/packages/core/src/utils/feature-flags.ts
@@ -2,6 +2,16 @@ import { cache } from "../lib/cache";
 
 const k = (name: string) => `flag:${name}`;
 
+function toBoolean(v: unknown): boolean {
+  if (v === true) return true;
+  if (typeof v === "number") return v !== 0;
+  if (typeof v === "string") {
+    const s = v.trim().toLowerCase();
+    return s === "true" || s === "1" || s === "yes" || s === "on";
+  }
+  return false;
+}
+
 export async function setFeatureFlag(
   name: string,
   enabled: boolean,
@@ -12,7 +22,7 @@ export async function setFeatureFlag(
 
 export async function isFeatureEnabled(name: string): Promise<boolean> {
   const v = await cache.get<string>(k(name));
-  return v === "true";
+  return toBoolean(v);
 }
 
 export async function clearFeatureFlag(name: string) {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@otm/typescript-config/base.json",
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -6,12 +6,16 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
-    OTM_PROJECT_URL: z.string().min(1),
 
+    OTM_PROJECT_URL: z.string().min(1),
     OTM_DATABASE_URL: z.string().url(),
 
     OTM_UPSTASH_REDIS_REST_URL: z.string().url().optional(),
     OTM_UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+
+    OTM_REDIS_ENABLED: z.enum(["true", "false"]).default("false"),
+
+    OTM_LOCAL_REDIS_URL: z.string().url().optional(),
 
     GITHUB_CLIENT_ID: z.string().min(1),
     GITHUB_CLIENT_SECRET: z.string().min(1),

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -15,8 +15,6 @@ export const env = createEnv({
 
     OTM_REDIS_ENABLED: z.enum(["true", "false"]).default("false"),
 
-    OTM_LOCAL_REDIS_URL: z.string().url().optional(),
-
     GITHUB_CLIENT_ID: z.string().min(1),
     GITHUB_CLIENT_SECRET: z.string().min(1),
     GITHUB_TOKEN: z.string().min(1),
@@ -24,5 +22,14 @@ export const env = createEnv({
   experimental__runtimeEnv: process.env,
   skipValidation: process.env.NODE_ENV !== "production",
 });
+
+if (
+  env.OTM_REDIS_ENABLED === "true" &&
+  (!env.OTM_UPSTASH_REDIS_REST_URL || !env.OTM_UPSTASH_REDIS_REST_TOKEN)
+) {
+  throw new Error(
+    "OTM_REDIS_ENABLED=true requires OTM_UPSTASH_REDIS_REST_URL and OTM_UPSTASH_REDIS_REST_TOKEN"
+  );
+}
 
 export type ServerEnv = typeof env;


### PR DESCRIPTION
## Summary
This PR completes **Step 4** of the OTM v0.1 roadmap — wiring a safe, optional Upstash Redis cache and feature-flag helper.

### Key changes
- Added `@otm/core` package with:
  - `cache.ts`: unified cache interface (`get/set/del`)  
  - In-memory fallback (default for DX)
  - Upstash Redis provider (enabled when `OTM_REDIS_ENABLED=true`)
- Added `feature-flags.ts` utility:
  - `setFeatureFlag(name, enabled, ttl?)`
  - `isFeatureEnabled(name)` with truthy-safe parsing
  - `clearFeatureFlag(name)`
- Updated `@otm/env` to validate Upstash credentials when enabled
- Verified via smoke tests (`scripts/smoke.ts` + `scripts/flags-smoke.ts`)  
  - ✅ Memory mode prints `⚙️ OTM cache: in-memory`
  - ✅ Upstash mode prints `✅ OTM cache: Upstash (REST)`

### Environment variables
```bash
# default: in-memory cache
OTM_REDIS_ENABLED=false

# enable Upstash cache
OTM_UPSTASH_REDIS_REST_URL=<your-rest-url>
OTM_UPSTASH_REDIS_REST_TOKEN=<your-token>